### PR TITLE
Update to createAnnotationTag.py

### DIFF
--- a/Dynamo_0.8.X/createAnnotationTag.py
+++ b/Dynamo_0.8.X/createAnnotationTag.py
@@ -112,13 +112,13 @@ try:
 			if isinstance(views, list):
 				for i,j,k in zip(elements, views, locationPts):
 					location = toRvtPoint(k)
-					tag = doc.Create.NewTag(j, i, False, TagMode.TM_ADDBY_CATEGORY, TagOrientation.Horizontal, location)
+					tag = IndependentTag.Create(doc,j.Id, Reference(i), False, TagMode.TM_ADDBY_CATEGORY, TagOrientation.Horizontal, location)
 					tag.ChangeTypeId(tagTypeId)
 					tags.append(tag)
 			else:
 				for i, j in zip(elements, locationPts):
 					location = toRvtPoint(j)
-					tag = doc.Create.NewTag(views, i, False, TagMode.TM_ADDBY_CATEGORY, TagOrientation.Horizontal, location)
+					tag = IndependentTag.Create(doc,views.Id, Reference(i), False, TagMode.TM_ADDBY_CATEGORY, TagOrientation.Horizontal, location)
 					tag.ChangeTypeId(tagTypeId)
 					tags.append(tag)
 			TransactionManager.Instance.TransactionTaskDone()


### PR DESCRIPTION
between 2018 and 2019 the method changed form doc.Create.NewTag to IndependentTag.Create see the apidocs.co page https://apidocs.co/apps/revit/2019/9b5a74a0-f9bd-9892-23e0-9a344f514b02.htm doc went inside the method call.
Create(Document, ElementId, Reference, Boolean, TagMode, TagOrientation, XYZ) or Create(Document, ElementId, ElementId, Reference, Boolean, TagOrientation, XYZ) please test to confirm, but it worked for me.